### PR TITLE
Add asset management fund accounting schema and tasks

### DIFF
--- a/finance/asset_mgmt_fund_accounting/evidence/valuation_policy.json
+++ b/finance/asset_mgmt_fund_accounting/evidence/valuation_policy.json
@@ -1,0 +1,5 @@
+{
+  "nav_method": "market",
+  "valuation_time": "16:00 UTC",
+  "allowed_asset_types": ["EQUITY", "BOND", "CASH"]
+}

--- a/finance/asset_mgmt_fund_accounting/evidence_loader.py
+++ b/finance/asset_mgmt_fund_accounting/evidence_loader.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Load evidence files into evidence_kv for portable access."""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", required=True)
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.db)
+    conn.execute("CREATE TABLE IF NOT EXISTS evidence_kv (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+    ev_dir = Path(__file__).parent / "evidence"
+    for path in ev_dir.glob("*"):
+        if path.suffix not in {".json", ".md"}:
+            continue
+        if path.suffix == ".json":
+            text = path.read_text(encoding="utf-8")
+            json.loads(text)
+        else:
+            text = json.dumps(path.read_text(encoding="utf-8"))
+        conn.execute("INSERT OR REPLACE INTO evidence_kv VALUES (?, ?)", (path.stem, text))
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/finance/asset_mgmt_fund_accounting/generate_schema_normalized.py
+++ b/finance/asset_mgmt_fund_accounting/generate_schema_normalized.py
@@ -1,2 +1,66 @@
 #!/usr/bin/env python3
-"""Stub file for asset_mgmt_fund_accounting. Actual implementation required."""
+"""Generate normalized schema for asset management fund accounting."""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from common import ddl_validators as dv
+
+DDL = """
+PRAGMA foreign_keys=ON;
+CREATE TABLE funds (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    domicile TEXT NOT NULL CHECK(domicile IN ('US','EU','APAC')),
+    status TEXT NOT NULL CHECK(status IN ('ACTIVE','INACTIVE'))
+);
+CREATE TABLE investors (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    tier TEXT NOT NULL CHECK(tier IN ('RETAIL','INSTITUTIONAL')),
+    risk_profile TEXT NOT NULL CHECK(risk_profile IN ('LOW','MED','HIGH'))
+);
+CREATE TABLE securities (
+    id INTEGER PRIMARY KEY,
+    symbol TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL CHECK(type IN ('EQUITY','BOND','CASH')),
+    currency TEXT NOT NULL CHECK(currency IN ('USD','EUR','JPY'))
+);
+CREATE TABLE holdings (
+    id INTEGER PRIMARY KEY,
+    fund_id INTEGER NOT NULL REFERENCES funds(id),
+    security_id INTEGER NOT NULL REFERENCES securities(id),
+    quantity INTEGER NOT NULL CHECK(quantity>0),
+    position_date TEXT NOT NULL
+);
+CREATE TABLE subscriptions (
+    id INTEGER PRIMARY KEY,
+    fund_id INTEGER NOT NULL REFERENCES funds(id),
+    investor_id INTEGER NOT NULL REFERENCES investors(id),
+    subscribed_at TEXT NOT NULL
+);
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", default="schema_normalized.sql")
+    parser.add_argument("--db")
+    parser.add_argument("--echo", action="store_true")
+    args = parser.parse_args()
+
+    if args.echo:
+        print(DDL)
+    Path(args.out).write_text(DDL, encoding="utf-8")
+    if args.db:
+        conn = sqlite3.connect(args.db)
+        dv.pragma_foreign_keys_on(conn)
+        conn.executescript(DDL)
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/finance/asset_mgmt_fund_accounting/populate_denormalized.py
+++ b/finance/asset_mgmt_fund_accounting/populate_denormalized.py
@@ -1,2 +1,40 @@
 #!/usr/bin/env python3
-"""Stub file for asset_mgmt_fund_accounting. Actual implementation required."""
+"""Create denormalized fund positions mart."""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from common.utils import batch
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--source", default="asset_mgmt_fund_accounting_normalized.db")
+    args = parser.parse_args()
+
+    src = sqlite3.connect(args.source)
+    dst = sqlite3.connect(args.db)
+    dst.executescript(Path("schema_denormalized.sql").read_text())
+    rows = src.execute(
+        """
+        SELECT f.id, f.name, s.symbol, h.quantity, h.position_date
+        FROM holdings h
+        JOIN funds f ON h.fund_id=f.id
+        JOIN securities s ON h.security_id=s.id
+        """
+    ).fetchall()
+    for chunk in batch(rows, 500):
+        dst.executemany("INSERT INTO fund_positions VALUES (?,?,?,?,?)", chunk)
+    dst.execute("CREATE INDEX idx_fp_date ON fund_positions(position_date, fund_id)")
+    dst.execute("CREATE INDEX idx_fp_symbol ON fund_positions(security_symbol)")
+    dst.commit()
+    src.close()
+    dst.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/finance/asset_mgmt_fund_accounting/populate_normalized.py
+++ b/finance/asset_mgmt_fund_accounting/populate_normalized.py
@@ -1,2 +1,76 @@
 #!/usr/bin/env python3
-"""Stub file for asset_mgmt_fund_accounting. Actual implementation required."""
+"""Populate fund accounting normalized tables with deterministic data."""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from common.utils import get_rng, batch
+
+FUNDS = 3
+INVESTORS = 5
+SECURITIES = 5
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    rng = get_rng(args.seed)
+    conn = sqlite3.connect(args.db)
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    funds = [
+        (i, f"Fund {i}", rng.choice(['US','EU','APAC']), rng.choice(['ACTIVE','INACTIVE']))
+        for i in range(1, FUNDS + 1)
+    ]
+    conn.executemany("INSERT INTO funds VALUES (?,?,?,?)", funds)
+
+    investors = [
+        (i, f"Investor {i}", rng.choice(['RETAIL','INSTITUTIONAL']), rng.choice(['LOW','MED','HIGH']))
+        for i in range(1, INVESTORS + 1)
+    ]
+    conn.executemany("INSERT INTO investors VALUES (?,?,?,?)", investors)
+
+    securities = [
+        (i, f"SEC{i:03d}", rng.choice(['EQUITY','BOND','CASH']), rng.choice(['USD','EUR','JPY']))
+        for i in range(1, SECURITIES + 1)
+    ]
+    conn.executemany("INSERT INTO securities VALUES (?,?,?,?)", securities)
+
+    subs = []
+    sub_id = 1
+    for inv in range(1, INVESTORS + 1):
+        fund = rng.randint(1, FUNDS)
+        subs.append((sub_id, fund, inv, f"2024-01-{rng.randint(1,3):02d}"))
+        sub_id += 1
+    for chunk in batch(subs, 100):
+        conn.executemany("INSERT INTO subscriptions VALUES (?,?,?,?)", chunk)
+
+    holdings = []
+    hold_id = 1
+    for fund in range(1, FUNDS + 1):
+        for sec in rng.sample(range(1, SECURITIES + 1), 3):
+            qty = rng.randint(1, 1000)
+            date = f"2024-01-{rng.randint(1,3):02d}"
+            holdings.append((hold_id, fund, sec, qty, date))
+            hold_id += 1
+    for chunk in batch(holdings, 100):
+        conn.executemany("INSERT INTO holdings VALUES (?,?,?,?,?)", chunk)
+
+    conn.execute("CREATE INDEX idx_funds_status ON funds(status)")
+    conn.execute("CREATE INDEX idx_investors_tier ON investors(tier)")
+    conn.execute("CREATE INDEX idx_securities_type ON securities(type)")
+    conn.execute("CREATE INDEX idx_holdings_fund_date ON holdings(fund_id, position_date)")
+    conn.execute("CREATE INDEX idx_subs_fund_inv ON subscriptions(fund_id, investor_id)")
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/finance/asset_mgmt_fund_accounting/sample_text_to_sql_tasks.md
+++ b/finance/asset_mgmt_fund_accounting/sample_text_to_sql_tasks.md
@@ -1,3 +1,118 @@
 # Sample Tasks for asset_mgmt_fund_accounting
 
-<!-- TODO: add multi-turn tasks -->
+## Task 1: list funds
+**User**: Show all fund names.
+**Assistant**: Simple select.
+```sql
+SELECT name FROM funds;
+```
+
+## Task 2: evidence NAV method
+**User**: What's the NAV method per valuation_policy.json?
+**Assistant**: Read from evidence_kv.
+```sql
+SELECT json_extract((SELECT value FROM evidence_kv WHERE key='valuation_policy'), '$.nav_method');
+```
+
+## Task 3: indexed holdings lookup
+**User**: Get holdings for fund 1 on 2024-01-02.
+**Assistant**: Fast uses composite index; slow uses substr.
+```sql fast
+SELECT * FROM holdings WHERE fund_id=1 AND position_date='2024-01-02';
+```
+```sql slow
+SELECT * FROM holdings WHERE fund_id||''='1' AND substr(position_date,1,10)='2024-01-02';
+```
+
+## Task 4: investor tiers
+**User**: List institutional investors.
+**Assistant**: Filter by tier.
+```sql
+SELECT name FROM investors WHERE tier='INSTITUTIONAL';
+```
+
+## Task 5: fund subscriptions
+**User**: Which investors are in fund 2?
+**Assistant**: Join subscriptions and investors.
+```sql
+SELECT i.name FROM subscriptions s JOIN investors i ON s.investor_id=i.id WHERE s.fund_id=2;
+```
+
+## Task 6: evidence valuation time
+**User**: When do valuations occur?
+**Assistant**: Retrieve from JSON.
+```sql
+SELECT json_extract((SELECT value FROM evidence_kv WHERE key='valuation_policy'), '$.valuation_time');
+```
+
+## Task 7: efficiency investor count
+**User**: How many retail investors?
+**Assistant**: Fast uses indexed tier; slow uses LIKE.
+```sql fast
+SELECT name FROM investors WHERE tier='RETAIL';
+```
+```sql slow
+SELECT name FROM investors WHERE substr(tier,1,6)='RETAIL';
+```
+
+## Task 8: security list
+**User**: List equity securities.
+**Assistant**: Filter by type.
+```sql
+SELECT symbol FROM securities WHERE type='EQUITY';
+```
+
+## Task 9: holdings quantity sum
+**User**: Total quantity of SEC001 across funds.
+**Assistant**: Sum quantities.
+```sql
+SELECT SUM(quantity) FROM holdings h JOIN securities s ON h.security_id=s.id WHERE s.symbol='SEC001';
+```
+
+## Task 10: evidence asset types
+**User**: Which asset types are allowed?
+**Assistant**: Use evidence_kv.
+```sql
+SELECT json_extract((SELECT value FROM evidence_kv WHERE key='valuation_policy'), '$.allowed_asset_types');
+```
+
+## Task 11: monthly holdings range
+**User**: Show fund 1 holdings for January.
+**Assistant**: Fast uses BETWEEN; slow uses strftime.
+```sql fast
+SELECT * FROM holdings WHERE fund_id=1 AND position_date BETWEEN '2024-01-01' AND '2024-01-31';
+```
+```sql slow
+SELECT * FROM holdings WHERE fund_id||''='1' AND strftime('%m', position_date)='01';
+```
+
+## Task 12: efficiency symbol search
+**User**: Show holdings for SEC002.
+**Assistant**: Fast equality vs slow pattern.
+```sql fast
+SELECT * FROM holdings h JOIN securities s ON h.security_id=s.id WHERE s.symbol='SEC002';
+```
+```sql slow
+SELECT * FROM holdings h JOIN securities s ON h.security_id=s.id WHERE substr(s.symbol,1,6)='SEC002';
+```
+
+## Task 13: unsubscribed investors
+**User**: Which investors have no subscriptions?
+**Assistant**: Left join and filter null.
+```sql
+SELECT i.name FROM investors i LEFT JOIN subscriptions s ON i.id=s.investor_id GROUP BY i.id HAVING COUNT(s.id)=0;
+```
+
+## Task 14: fund domiciles
+**User**: Count funds by domicile.
+**Assistant**: Group by.
+```sql
+SELECT domicile, COUNT(*) FROM funds GROUP BY domicile;
+```
+
+## Task 15: evidence raw policy
+**User**: Return raw valuation policy text.
+**Assistant**: Extract entire JSON.
+```sql
+SELECT json_extract((SELECT value FROM evidence_kv WHERE key='valuation_policy'), '$');
+```

--- a/finance/asset_mgmt_fund_accounting/sanity_checks.sql
+++ b/finance/asset_mgmt_fund_accounting/sanity_checks.sql
@@ -1,1 +1,13 @@
--- TODO: add SQL for asset_mgmt_fund_accounting
+-- Sanity checks for fund accounting
+SELECT CASE WHEN COUNT(*)=3 THEN 1 ELSE 1/0 END FROM funds;
+SELECT CASE WHEN COUNT(*)=5 THEN 1 ELSE 1/0 END FROM investors;
+SELECT CASE WHEN COUNT(*)=5 THEN 1 ELSE 1/0 END FROM securities;
+SELECT CASE WHEN COUNT(*)=0 THEN 1 ELSE 1/0 END FROM holdings WHERE quantity<=0;
+SELECT CASE WHEN COUNT(*)=0 THEN 1 ELSE 1/0 END FROM holdings h LEFT JOIN funds f ON h.fund_id=f.id WHERE f.id IS NULL;
+SELECT CASE WHEN COUNT(*)=0 THEN 1 ELSE 1/0 END FROM investors WHERE tier NOT IN ('RETAIL','INSTITUTIONAL');
+SELECT CASE WHEN COUNT(*)=0 THEN 1 ELSE 1/0 END FROM securities WHERE type NOT IN ('EQUITY','BOND','CASH');
+SELECT CASE WHEN COUNT(*)=5 THEN 1 ELSE 1/0 END FROM subscriptions;
+SELECT CASE WHEN COUNT(*)=0 THEN 1 ELSE 1/0 END FROM subscriptions s LEFT JOIN investors i ON s.investor_id=i.id WHERE i.id IS NULL;
+SELECT CASE WHEN COUNT(*)=0 THEN 1 ELSE 1/0 END FROM funds f LEFT JOIN subscriptions s ON f.id=s.fund_id GROUP BY f.id HAVING COUNT(s.id)=0;
+SELECT CASE WHEN COUNT(*)=0 THEN 1 ELSE 1/0 END FROM (SELECT fund_id, security_id, position_date, COUNT(*) c FROM holdings GROUP BY fund_id, security_id, position_date HAVING c>1);
+SELECT CASE WHEN MIN(position_date)>='2024-01-01' THEN 1 ELSE 1/0 END FROM holdings;

--- a/finance/asset_mgmt_fund_accounting/schema_denormalized.sql
+++ b/finance/asset_mgmt_fund_accounting/schema_denormalized.sql
@@ -1,1 +1,11 @@
--- TODO: add SQL for asset_mgmt_fund_accounting
+-- Denormalized fund positions summary. Trades off storage duplication for
+-- faster analytical scans.
+PRAGMA foreign_keys=OFF;
+CREATE TABLE IF NOT EXISTS fund_positions (
+    fund_id INTEGER NOT NULL,
+    fund_name TEXT NOT NULL,
+    security_symbol TEXT NOT NULL,
+    quantity INTEGER NOT NULL,
+    position_date TEXT NOT NULL,
+    PRIMARY KEY (fund_id, security_symbol, position_date)
+);

--- a/finance/asset_mgmt_fund_accounting/schema_normalized.sql
+++ b/finance/asset_mgmt_fund_accounting/schema_normalized.sql
@@ -1,1 +1,38 @@
--- TODO: add SQL for asset_mgmt_fund_accounting
+PRAGMA foreign_keys=ON;
+CREATE TABLE funds (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    domicile TEXT NOT NULL CHECK(domicile IN ('US','EU','APAC')),
+    status TEXT NOT NULL CHECK(status IN ('ACTIVE','INACTIVE'))
+);
+CREATE TABLE investors (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    tier TEXT NOT NULL CHECK(tier IN ('RETAIL','INSTITUTIONAL')),
+    risk_profile TEXT NOT NULL CHECK(risk_profile IN ('LOW','MED','HIGH'))
+);
+CREATE TABLE securities (
+    id INTEGER PRIMARY KEY,
+    symbol TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL CHECK(type IN ('EQUITY','BOND','CASH')),
+    currency TEXT NOT NULL CHECK(currency IN ('USD','EUR','JPY'))
+);
+CREATE TABLE holdings (
+    id INTEGER PRIMARY KEY,
+    fund_id INTEGER NOT NULL REFERENCES funds(id),
+    security_id INTEGER NOT NULL REFERENCES securities(id),
+    quantity INTEGER NOT NULL CHECK(quantity>0),
+    position_date TEXT NOT NULL
+);
+CREATE TABLE subscriptions (
+    id INTEGER PRIMARY KEY,
+    fund_id INTEGER NOT NULL REFERENCES funds(id),
+    investor_id INTEGER NOT NULL REFERENCES investors(id),
+    subscribed_at TEXT NOT NULL
+);
+-- Indexes created post-load for performance
+-- CREATE INDEX idx_funds_status ON funds(status);
+-- CREATE INDEX idx_investors_tier ON investors(tier);
+-- CREATE INDEX idx_securities_type ON securities(type);
+-- CREATE INDEX idx_holdings_fund_date ON holdings(fund_id, position_date);
+-- CREATE INDEX idx_subs_fund_inv ON subscriptions(fund_id, investor_id);

--- a/finance/workflow_tasks.md
+++ b/finance/workflow_tasks.md
@@ -38,3 +38,21 @@ JOIN chargebacks cb ON cb.card_transaction_id=b.id GROUP BY b.merchant_id;
 -- depends: cb
 SELECT merchant_id, cb_amt FROM cb WHERE cb_amt>10000;
 ```
+
+## Task: fund nav workflow
+```sql
+-- step: base
+CREATE TEMP TABLE base AS
+SELECT h.fund_id, s.type, h.quantity FROM holdings h JOIN securities s ON h.security_id=s.id;
+```
+```sql
+-- step: nav
+-- depends: base
+CREATE TEMP TABLE nav AS
+SELECT fund_id, SUM(quantity) nav_qty FROM base GROUP BY fund_id;
+```
+```sql
+-- step: final
+-- depends: nav
+SELECT * FROM nav WHERE nav_qty>1000;
+```


### PR DESCRIPTION
## Summary
- define normalized asset management tables (funds, investors, securities, holdings, subscriptions) with foreign keys, enums, and post-load indexes
- add deterministic loaders and denormalized mart with analytical indexes and valuation policy evidence
- include sanity checks, workflow example, and multi-turn tasks with fast/slow SQL pairs

## Testing
- `python scripts/diversity_guard.py` *(fails: numerous other subdomains missing schemas/indexes)*
- `python scripts/workflow_guard.py`
- `python scripts/evidence_schema.py`
- `python -m scripts.run_checks --domain Finance` *(fails: missing normalized DBs for other finance subdomains)*
- `python scripts/efficiency_guard.py` *(fails: many subdomains missing DBs)*

------
https://chatgpt.com/codex/tasks/task_e_68bd33365868832fb4a0517fa6110521