### PR TITLE
Add SCADA telemetry schema and workflows

### DIFF
--- a/energy_manufacturing/scada_telemetry_timeseries/evidence/sensor_specs.json
+++ b/energy_manufacturing/scada_telemetry_timeseries/evidence/sensor_specs.json
@@ -1,0 +1,4 @@
+{
+  "temp_unit": "C",
+  "pressure_max": 500
+}

--- a/energy_manufacturing/scada_telemetry_timeseries/populate_denormalized.py
+++ b/energy_manufacturing/scada_telemetry_timeseries/populate_denormalized.py
@@ -1,11 +1,32 @@
 #!/usr/bin/env python3
-"""Populate denormalized table for SCADA telemetry."""
+"""Populate denormalized daily averages for SCADA telemetry."""
 from __future__ import annotations
-import argparse, sqlite3
+
+import argparse
+import sqlite3
 from pathlib import Path
 
-def main()->None:
-    p=argparse.ArgumentParser(); p.add_argument('--db',required=True); args=p.parse_args()
-    conn=sqlite3.connect(args.db); conn.executescript(Path('schema_denormalized.sql').read_text()); conn.commit(); conn.close()
-if __name__=='__main__':
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--db", required=True)
+    p.add_argument("--source", default="scada_telemetry_timeseries_normalized.db")
+    args = p.parse_args()
+
+    src = sqlite3.connect(args.source)
+    dst = sqlite3.connect(args.db)
+    ddl_path = Path(__file__).with_name("schema_denormalized.sql")
+    dst.executescript(ddl_path.read_text())
+    rows = src.execute("""
+        SELECT substr(reading_time,1,10) AS day, sensor_id, AVG(value)
+        FROM readings
+        GROUP BY day, sensor_id
+        """).fetchall()
+    dst.executemany("INSERT INTO sensor_daily_avg VALUES (?,?,?)", rows)
+    dst.commit()
+    src.close()
+    dst.close()
+
+
+if __name__ == "__main__":
     main()

--- a/energy_manufacturing/scada_telemetry_timeseries/populate_normalized.py
+++ b/energy_manufacturing/scada_telemetry_timeseries/populate_normalized.py
@@ -1,20 +1,59 @@
 #!/usr/bin/env python3
-"""Populate SCADA telemetry normalized schema."""
+"""Populate SCADA telemetry schema with synthetic data."""
 from __future__ import annotations
-import argparse, sqlite3
-from pathlib import Path
-SCALE_ASSETS=50
-SCALE_READINGS=500000
 
-def main()->None:
-    p=argparse.ArgumentParser(); p.add_argument('--db',required=True); args=p.parse_args()
-    conn=sqlite3.connect(args.db)
-    conn.executescript(Path('schema_normalized.sql').read_text())
-    # TODO populate
-    conn.executescript('''
-    CREATE INDEX idx_sensor_asset ON sensors(asset_id);
-    CREATE INDEX idx_reading_sensor_time ON readings(sensor_id, reading_time);
-    ''')
-    conn.commit(); conn.close()
-if __name__=='__main__':
+import argparse
+import sqlite3
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from common.utils import get_rng
+
+SITES = 2
+SENSORS_PER_SITE = 3
+READINGS_PER_SENSOR = 10
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    rng = get_rng(args.seed)
+    conn = sqlite3.connect(args.db)
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    sites = [(i, f'Plant {i}') for i in range(1, SITES + 1)]
+    conn.executemany("INSERT INTO sites VALUES (?,?)", sites)
+
+    sensors = []
+    sid = 1
+    for site_id in range(1, SITES + 1):
+        sensors.append((sid, site_id, f'Temp{site_id}', 'C', 'ACTIVE')); sid += 1
+        sensors.append((sid, site_id, f'Pressure{site_id}', 'psi', 'ACTIVE')); sid += 1
+        sensors.append((sid, site_id, f'Power{site_id}', 'kW', 'INACTIVE')); sid += 1
+    conn.executemany("INSERT INTO sensors VALUES (?,?,?,?,?)", sensors)
+
+    readings = []
+    rid = 1
+    for sensor_id, site_id, name, unit, status in sensors:
+        for i in range(READINGS_PER_SENSOR):
+            time = f"2024-01-{(i % 5) + 1:02d}T{(i % 24):02d}:00"
+            if unit == 'C':
+                value = rng.uniform(20, 80)
+            elif unit == 'psi':
+                value = rng.uniform(100, 450)
+            else:
+                value = rng.uniform(10, 90)
+            quality = rng.choice(['GOOD', 'BAD'])
+            readings.append((rid, sensor_id, time, round(value, 2), quality))
+            rid += 1
+    conn.executemany("INSERT INTO readings VALUES (?,?,?,?,?)", readings)
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
     main()

--- a/energy_manufacturing/scada_telemetry_timeseries/sample_text_to_sql_tasks.md
+++ b/energy_manufacturing/scada_telemetry_timeseries/sample_text_to_sql_tasks.md
@@ -1,25 +1,39 @@
 # Sample Tasks for scada_telemetry_timeseries
 
-## Task 1: temperature readings
-**User**: Fetch temperature readings for sensor 1 on 2024-01-01.
-**Assistant**: Filter readings.
+## Task 1: reading count
+**User**: How many readings does sensor 1 have?
+**Assistant**: Count readings for sensor 1.
 ```sql
-SELECT * FROM readings WHERE sensor_id=1 AND reading_time LIKE '2024-01-01%';
+SELECT COUNT(*) FROM readings WHERE sensor_id=1;
 ```
 
-## Task 2: evidence shift calendar
-**User**: What are the shifts?
-**Assistant**: Read shift_calendar.md via evidence_kv.
+## Task 2: evidence temperature unit
+**User**: What unit should temperature sensors use per specs?
+**Assistant**: Query sensor_specs in evidence_kv.
 ```sql
-SELECT json_extract((SELECT value FROM evidence_kv WHERE key='shift_calendar'), '$');
+SELECT json_extract((SELECT value FROM evidence_kv WHERE key='sensor_specs'), '$.temp_unit');
 ```
 
-## Task 3: efficiency reading lookup
-**User**: Readings for sensor 2 at a timestamp.
-**Assistant**: Fast uses index.
+## Task 3: efficiency timestamp filter
+**User**: Readings for sensor 2 on 2024-01-02.
+**Assistant**: Fast uses equality; slow uses substr.
 ```sql fast
-SELECT value FROM readings WHERE sensor_id=2 AND reading_time='2024-01-02T00:00:00';
+SELECT value FROM readings WHERE sensor_id=2 AND reading_time='2024-01-02T00:00';
 ```
 ```sql slow
-SELECT value FROM readings WHERE sensor_id=2 AND substr(reading_time,1,19)='2024-01-02T00:00:00';
+SELECT value FROM readings WHERE sensor_id=2 AND substr(reading_time,1,16)='2024-01-02T00:00';
+```
+
+## Task 4: evidence pressure max
+**User**: What is max allowed pressure?
+**Assistant**: Fetch from sensor_specs.
+```sql
+SELECT json_extract((SELECT value FROM evidence_kv WHERE key='sensor_specs'), '$.pressure_max');
+```
+
+## Task 5: sensors per site
+**User**: How many sensors in each site?
+**Assistant**: Group sensors by site.
+```sql
+SELECT site_id, COUNT(*) FROM sensors GROUP BY site_id;
 ```

--- a/energy_manufacturing/scada_telemetry_timeseries/sanity_checks.sql
+++ b/energy_manufacturing/scada_telemetry_timeseries/sanity_checks.sql
@@ -1,8 +1,17 @@
--- average reading per sensor
-SELECT sensor_id, AVG(value) FROM readings GROUP BY sensor_id;
-
--- join assets
-SELECT a.name, COUNT(r.id) FROM readings r JOIN sensors s ON r.sensor_id=s.id JOIN assets a ON s.asset_id=a.id GROUP BY a.id;
-
--- readings in shift
-SELECT COUNT(*) FROM readings WHERE reading_time BETWEEN '2024-01-01' AND '2024-01-02';
+-- 1. sensors reference valid sites
+SELECT COUNT(*) FROM sensors s LEFT JOIN sites si ON s.site_id=si.id WHERE si.id IS NULL;
+-- 2. readings reference valid sensors
+SELECT COUNT(*) FROM readings r LEFT JOIN sensors s ON r.sensor_id=s.id WHERE s.id IS NULL;
+-- 3. sensor unit enum
+SELECT COUNT(*) FROM sensors WHERE unit NOT IN ('C','F','kW','psi');
+-- 4. sensor status enum
+SELECT COUNT(*) FROM sensors WHERE status NOT IN ('ACTIVE','INACTIVE','MAINTENANCE');
+-- 5. reading quality enum
+SELECT COUNT(*) FROM readings WHERE quality NOT IN ('GOOD','BAD');
+-- 6. pressure readings within spec
+SELECT COUNT(*) FROM readings r JOIN sensors s ON r.sensor_id=s.id
+WHERE s.unit='psi' AND r.value > json_extract((SELECT value FROM evidence_kv WHERE key='sensor_specs'), '$.pressure_max');
+-- 7. temperature unit matches spec
+SELECT COUNT(*) FROM sensors WHERE name LIKE 'Temp%' AND unit != json_extract((SELECT value FROM evidence_kv WHERE key='sensor_specs'), '$.temp_unit');
+-- 8. EXPLAIN uses index on readings
+EXPLAIN QUERY PLAN SELECT * FROM readings WHERE sensor_id=1 ORDER BY reading_time;

--- a/energy_manufacturing/scada_telemetry_timeseries/schema_denormalized.sql
+++ b/energy_manufacturing/scada_telemetry_timeseries/schema_denormalized.sql
@@ -1,6 +1,8 @@
 PRAGMA foreign_keys=OFF;
-CREATE TABLE sensor_readings AS
-SELECT r.id AS reading_id, a.name AS asset_name, s.type, r.reading_time, r.value
-FROM readings r
-JOIN sensors s ON r.sensor_id=s.id
-JOIN assets a ON s.asset_id=a.id;
+CREATE TABLE IF NOT EXISTS sensor_daily_avg (
+    day TEXT NOT NULL,
+    sensor_id INTEGER NOT NULL,
+    avg_value REAL NOT NULL,
+    PRIMARY KEY(day, sensor_id)
+);
+CREATE INDEX idx_sda_day ON sensor_daily_avg(day);

--- a/energy_manufacturing/scada_telemetry_timeseries/schema_normalized.sql
+++ b/energy_manufacturing/scada_telemetry_timeseries/schema_normalized.sql
@@ -1,23 +1,21 @@
 PRAGMA foreign_keys=ON;
-CREATE TABLE assets (
+CREATE TABLE sites (
     id INTEGER PRIMARY KEY,
     name TEXT NOT NULL
 );
 CREATE TABLE sensors (
     id INTEGER PRIMARY KEY,
-    asset_id INTEGER NOT NULL REFERENCES assets(id),
-    type TEXT NOT NULL CHECK(type IN ('TEMP','PRESSURE','FLOW'))
+    site_id INTEGER NOT NULL REFERENCES sites(id),
+    name TEXT NOT NULL,
+    unit TEXT NOT NULL CHECK(unit IN ('C','F','kW','psi')),
+    status TEXT NOT NULL CHECK(status IN ('ACTIVE','INACTIVE','MAINTENANCE'))
 );
-CREATE INDEX idx_sensor_asset ON sensors(asset_id);
+CREATE INDEX idx_sensors_site ON sensors(site_id);
 CREATE TABLE readings (
     id INTEGER PRIMARY KEY,
     sensor_id INTEGER NOT NULL REFERENCES sensors(id),
     reading_time TEXT NOT NULL,
-    value NUMERIC NOT NULL
+    value REAL NOT NULL,
+    quality TEXT NOT NULL CHECK(quality IN ('GOOD','BAD'))
 );
-CREATE INDEX idx_reading_sensor_time ON readings(sensor_id, reading_time);
-CREATE TABLE shift_calendar (
-    id INTEGER PRIMARY KEY,
-    day TEXT NOT NULL,
-    shift TEXT NOT NULL
-);
+CREATE INDEX idx_readings_sensor_time ON readings(sensor_id, reading_time);

--- a/energy_manufacturing/workflow_tasks.md
+++ b/energy_manufacturing/workflow_tasks.md
@@ -31,3 +31,21 @@ SELECT line_id, start_time, end_time FROM downtime_events;
 SELECT line_id, (julianday(end_time)-julianday(start_time))*24 AS hours FROM base;
 ```
 
+## Task: sensor daily avg
+```sql
+-- step: raw
+CREATE TEMP TABLE raw AS
+SELECT sensor_id, reading_time, value FROM readings;
+```
+```sql
+-- step: day
+-- depends: raw
+CREATE TEMP TABLE day AS
+SELECT sensor_id, substr(reading_time,1,10) AS day, value FROM raw;
+```
+```sql
+-- step: agg
+-- depends: day
+SELECT sensor_id, day, AVG(value) avg_v FROM day GROUP BY sensor_id, day;
+```
+


### PR DESCRIPTION
## Summary
- define SCADA telemetry schema with enums, PK/FK, and indexes
- populate normalized and denormalized tables and load evidence
- add sanity checks, sample tasks, and workflow for daily sensor averages

## Testing
- `python energy_manufacturing/scada_telemetry_timeseries/generate_schema_normalized.py --db energy_manufacturing/scada_telemetry_timeseries/scada_telemetry_timeseries_normalized.db`
- `python energy_manufacturing/scada_telemetry_timeseries/populate_normalized.py --db energy_manufacturing/scada_telemetry_timeseries/scada_telemetry_timeseries_normalized.db`
- `python energy_manufacturing/scada_telemetry_timeseries/evidence_loader.py --db energy_manufacturing/scada_telemetry_timeseries/scada_telemetry_timeseries_normalized.db`
- `python energy_manufacturing/scada_telemetry_timeseries/populate_denormalized.py --db energy_manufacturing/scada_telemetry_timeseries/scada_telemetry_timeseries_denormalized.db --source energy_manufacturing/scada_telemetry_timeseries/scada_telemetry_timeseries_normalized.db`
- `sqlite3 energy_manufacturing/scada_telemetry_timeseries/scada_telemetry_timeseries_normalized.db ".read energy_manufacturing/scada_telemetry_timeseries/sanity_checks.sql"`
- `python scripts/workflow_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd3337cf08832f94e9aca82a46570e