### PR TITLE
Add assortment catalog schema and mart

### DIFF
--- a/retail_cpg/assortment_catalog/README.md
+++ b/retail_cpg/assortment_catalog/README.md
@@ -1,3 +1,23 @@
 # assortment_catalog
 
-TODO: document entities, indexes and efficiency notes.
+Captures product assortment, categories, suppliers and attributes for a retail catalog.
+
+## Entities
+- categories – unique catalog categories
+- suppliers – product suppliers with active/inactive lifecycle
+- products – SKU-level items linked to category and supplier
+- product_attributes – flexible attribute key/value
+
+## Indexes
+- `idx_products_category (category_id)`
+- `idx_products_supplier (supplier_id)`
+- `idx_attr_product (product_id)`
+
+## Scale
+~3 categories, 3 suppliers, 9 products, 18 attributes.
+
+## Efficiency Notes
+Indexes support filtering by category and supplier. Sample tasks show indexed lookups vs scans on computed fields.
+
+## Denormalized Mart Trade-offs
+The `product_catalog` mart duplicates category and supplier names for quick analytics but introduces redundancy; updates require rebuilding the mart.

--- a/retail_cpg/assortment_catalog/evidence/catalog_policy.md
+++ b/retail_cpg/assortment_catalog/evidence/catalog_policy.md
@@ -1,0 +1,1 @@
+Products must belong to a valid category and inactive suppliers cannot add new items.

--- a/retail_cpg/assortment_catalog/evidence_loader.py
+++ b/retail_cpg/assortment_catalog/evidence_loader.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Load evidence files into evidence_kv for assortment catalog."""
+from __future__ import annotations
+import argparse, json, sqlite3
+from pathlib import Path
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument('--db', required=True)
+    args = p.parse_args()
+    conn = sqlite3.connect(args.db)
+    conn.execute("CREATE TABLE IF NOT EXISTS evidence_kv (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+    ev_dir = Path(__file__).parent / 'evidence'
+    for path in ev_dir.glob('*'):
+        if path.suffix not in {'.json', '.md'}:
+            continue
+        if path.suffix == '.json':
+            text = path.read_text(encoding='utf-8')
+            json.loads(text)
+        else:
+            text = json.dumps(path.read_text(encoding='utf-8'))
+        conn.execute("INSERT OR REPLACE INTO evidence_kv VALUES (?,?)", (path.stem, text))
+    conn.commit(); conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/retail_cpg/assortment_catalog/generate_schema_normalized.py
+++ b/retail_cpg/assortment_catalog/generate_schema_normalized.py
@@ -1,2 +1,55 @@
 #!/usr/bin/env python3
-"""Stub file for assortment_catalog. Actual implementation required."""
+"""Generate normalized schema for assortment catalog."""
+from __future__ import annotations
+import argparse, sqlite3
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from common import ddl_validators as dv
+DDL = """
+PRAGMA foreign_keys=ON;
+CREATE TABLE categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+CREATE TABLE suppliers (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK(status IN ('ACTIVE','INACTIVE'))
+);
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY,
+    sku TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    category_id INTEGER NOT NULL REFERENCES categories(id),
+    supplier_id INTEGER NOT NULL REFERENCES suppliers(id),
+    status TEXT NOT NULL CHECK(status IN ('ACTIVE','DISCONTINUED')),
+    price_cents INTEGER NOT NULL CHECK(price_cents>0)
+);
+CREATE TABLE product_attributes (
+    id INTEGER PRIMARY KEY,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    attribute TEXT NOT NULL,
+    value TEXT NOT NULL
+);
+CREATE INDEX idx_products_category ON products(category_id);
+CREATE INDEX idx_products_supplier ON products(supplier_id);
+CREATE INDEX idx_attr_product ON product_attributes(product_id);
+"""
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument('--out', default='schema_normalized.sql')
+    p.add_argument('--db')
+    p.add_argument('--echo', action='store_true')
+    args = p.parse_args()
+    if args.echo:
+        print(DDL)
+    Path(args.out).write_text(DDL, encoding='utf-8')
+    if args.db:
+        conn = sqlite3.connect(args.db)
+        dv.pragma_foreign_keys_on(conn)
+        conn.executescript(DDL)
+        conn.close()
+if __name__ == '__main__':
+    main()

--- a/retail_cpg/assortment_catalog/populate_denormalized.py
+++ b/retail_cpg/assortment_catalog/populate_denormalized.py
@@ -1,2 +1,45 @@
 #!/usr/bin/env python3
-"""Stub file for assortment_catalog. Actual implementation required."""
+"""Build denormalized product_catalog from normalized tables."""
+from __future__ import annotations
+import argparse, sqlite3
+from pathlib import Path
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument('--db', required=True)
+    p.add_argument('--source', default=str(Path(__file__).with_name('assortment_catalog_normalized.db')))
+    args = p.parse_args()
+    src = sqlite3.connect(args.source)
+    dst = sqlite3.connect(args.db)
+    dst.executescript("""
+    DROP TABLE IF EXISTS product_catalog;
+    CREATE TABLE product_catalog (
+        product_id INTEGER PRIMARY KEY,
+        sku TEXT NOT NULL,
+        product_name TEXT NOT NULL,
+        category_name TEXT NOT NULL,
+        supplier_name TEXT NOT NULL,
+        status TEXT NOT NULL,
+        price_cents INTEGER NOT NULL
+    );
+    """)
+    rows = src.execute(
+        """
+        SELECT p.id, p.sku, p.name, c.name, s.name, p.status, p.price_cents
+        FROM products p
+        JOIN categories c ON p.category_id=c.id
+        JOIN suppliers s ON p.supplier_id=s.id
+        """
+    ).fetchall()
+    dst.executemany("INSERT INTO product_catalog VALUES (?,?,?,?,?,?,?)", rows)
+    dst.executescript("""
+    CREATE INDEX idx_pc_category ON product_catalog(category_name);
+    CREATE INDEX idx_pc_supplier ON product_catalog(supplier_name);
+    """)
+    dst.commit()
+    src.close(); dst.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/retail_cpg/assortment_catalog/populate_normalized.py
+++ b/retail_cpg/assortment_catalog/populate_normalized.py
@@ -1,2 +1,51 @@
 #!/usr/bin/env python3
-"""Stub file for assortment_catalog. Actual implementation required."""
+"""Populate assortment catalog normalized tables with synthetic data."""
+from __future__ import annotations
+import argparse, sqlite3
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from common.utils import get_rng
+
+CATS = ["Beverages","Snacks","Household"]
+SUPPLIERS = ["Acme Co","Globex","Soylent"]
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument('--db', required=True)
+    p.add_argument('--seed', type=int, default=0)
+    args = p.parse_args()
+    rng = get_rng(args.seed)
+    conn = sqlite3.connect(args.db)
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    conn.executemany(
+        "INSERT INTO categories VALUES (?,?)",
+        [(i+1, name) for i, name in enumerate(CATS)]
+    )
+    conn.executemany(
+        "INSERT INTO suppliers VALUES (?,?,?)",
+        [(i+1, name, rng.choice(['ACTIVE','INACTIVE'])) for i, name in enumerate(SUPPLIERS)]
+    )
+    products = []
+    attrs = []
+    pid = 1
+    for cat_id in range(1, len(CATS)+1):
+        for _ in range(3):
+            sup_id = rng.randint(1, len(SUPPLIERS))
+            status = rng.choice(['ACTIVE','DISCONTINUED'])
+            price = rng.randint(100, 1000)
+            sku = f"SKU{pid:04d}"
+            name = f"Product {pid}"
+            products.append((pid, sku, name, cat_id, sup_id, status, price))
+            attrs.append((len(attrs)+1, pid, 'color', rng.choice(['red','blue','green'])))
+            attrs.append((len(attrs)+1, pid, 'size', rng.choice(['S','M','L'])))
+            pid += 1
+    conn.executemany("INSERT INTO products VALUES (?,?,?,?,?,?,?)", products)
+    conn.executemany("INSERT INTO product_attributes VALUES (?,?,?,?)", attrs)
+    conn.commit(); conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/retail_cpg/assortment_catalog/sample_text_to_sql_tasks.md
+++ b/retail_cpg/assortment_catalog/sample_text_to_sql_tasks.md
@@ -1,3 +1,25 @@
 # Sample Tasks for assortment_catalog
 
-<!-- TODO: add multi-turn tasks -->
+## Task 1: list beverages
+**User**: Show SKUs for products in the Beverages category.
+**Assistant**: Join products to categories and filter by name.
+```sql
+SELECT p.sku FROM products p JOIN categories c ON p.category_id=c.id WHERE c.name='Beverages';
+```
+
+## Task 2: evidence policy
+**User**: Can inactive suppliers add new items?
+**Assistant**: Read catalog_policy.md via evidence_kv.
+```sql
+SELECT json_extract((SELECT value FROM evidence_kv WHERE key='catalog_policy'), '$');
+```
+
+## Task 3: fast vs slow supplier lookup
+**User**: List active products from supplier 1; include slow alt.
+**Assistant**: Fast query filters by supplier_id using index; slow uses function on supplier name.
+```sql fast
+SELECT id, name FROM products WHERE supplier_id=1 AND status='ACTIVE';
+```
+```sql slow
+SELECT p.id, p.name FROM products p JOIN suppliers s ON p.supplier_id=s.id WHERE lower(s.name)='acme co' AND p.status='ACTIVE';
+```

--- a/retail_cpg/assortment_catalog/sanity_checks.sql
+++ b/retail_cpg/assortment_catalog/sanity_checks.sql
@@ -1,1 +1,20 @@
--- TODO: add SQL for assortment_catalog
+-- 1 count categories
+SELECT COUNT(*) FROM categories;
+-- 2 unique suppliers
+SELECT COUNT(DISTINCT name) FROM suppliers;
+-- 3 products per category
+SELECT category_id, COUNT(*) FROM products GROUP BY category_id;
+-- 4 products joined to suppliers
+SELECT COUNT(*) FROM products p JOIN suppliers s ON p.supplier_id=s.id;
+-- 5 attribute count
+SELECT COUNT(*) FROM product_attributes;
+-- 6 active products
+SELECT COUNT(*) FROM products WHERE status='ACTIVE';
+-- 7 negative price check (expect 0)
+SELECT COUNT(*) FROM products WHERE price_cents<=0;
+-- 8 products lacking attributes
+SELECT COUNT(*) FROM products p LEFT JOIN product_attributes a ON p.id=a.product_id GROUP BY p.id HAVING COUNT(a.id)=0;
+-- 9 supplier status counts
+SELECT status, COUNT(*) FROM suppliers GROUP BY status;
+--10 average price per category
+SELECT category_id, AVG(price_cents) FROM products GROUP BY category_id;

--- a/retail_cpg/assortment_catalog/schema_denormalized.sql
+++ b/retail_cpg/assortment_catalog/schema_denormalized.sql
@@ -1,1 +1,12 @@
--- TODO: add SQL for assortment_catalog
+PRAGMA foreign_keys=OFF;
+CREATE TABLE product_catalog (
+    product_id INTEGER PRIMARY KEY,
+    sku TEXT NOT NULL,
+    product_name TEXT NOT NULL,
+    category_name TEXT NOT NULL,
+    supplier_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    price_cents INTEGER NOT NULL
+);
+CREATE INDEX idx_pc_category ON product_catalog(category_name);
+CREATE INDEX idx_pc_supplier ON product_catalog(supplier_name);

--- a/retail_cpg/assortment_catalog/schema_normalized.sql
+++ b/retail_cpg/assortment_catalog/schema_normalized.sql
@@ -1,1 +1,29 @@
--- TODO: add SQL for assortment_catalog
+
+PRAGMA foreign_keys=ON;
+CREATE TABLE categories (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+CREATE TABLE suppliers (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK(status IN ('ACTIVE','INACTIVE'))
+);
+CREATE TABLE products (
+    id INTEGER PRIMARY KEY,
+    sku TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    category_id INTEGER NOT NULL REFERENCES categories(id),
+    supplier_id INTEGER NOT NULL REFERENCES suppliers(id),
+    status TEXT NOT NULL CHECK(status IN ('ACTIVE','DISCONTINUED')),
+    price_cents INTEGER NOT NULL CHECK(price_cents>0)
+);
+CREATE TABLE product_attributes (
+    id INTEGER PRIMARY KEY,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    attribute TEXT NOT NULL,
+    value TEXT NOT NULL
+);
+CREATE INDEX idx_products_category ON products(category_id);
+CREATE INDEX idx_products_supplier ON products(supplier_id);
+CREATE INDEX idx_attr_product ON product_attributes(product_id);

--- a/retail_cpg/assortment_catalog/workflow_tasks.md
+++ b/retail_cpg/assortment_catalog/workflow_tasks.md
@@ -1,0 +1,40 @@
+# Workflow Tasks
+
+## Task: attribute pivot
+```sql
+-- step: base
+CREATE TEMP TABLE base AS
+SELECT p.id, a.attribute, a.value FROM products p
+JOIN product_attributes a ON p.id=a.product_id;
+```
+```sql
+-- step: pivot
+-- depends: base
+CREATE TEMP TABLE pivoted AS
+SELECT id,
+       MAX(CASE WHEN attribute='color' THEN value END) color,
+       MAX(CASE WHEN attribute='size' THEN value END) size
+FROM base GROUP BY id;
+```
+```sql
+-- step: final
+-- depends: pivot
+SELECT * FROM pivoted;
+```
+
+## Task: discontinue inactive supplier products
+```sql
+-- step: find
+CREATE TEMP TABLE inactive AS
+SELECT p.id FROM products p JOIN suppliers s ON p.supplier_id=s.id WHERE s.status='INACTIVE';
+```
+```sql
+-- step: mark
+-- depends: find
+UPDATE products SET status='DISCONTINUED' WHERE id IN (SELECT id FROM inactive);
+```
+```sql
+-- step: verify
+-- depends: mark
+SELECT COUNT(*) FROM products p JOIN suppliers s ON p.supplier_id=s.id WHERE s.status='INACTIVE' AND p.status!='DISCONTINUED';
+```

--- a/retail_cpg/pos_sales_returns/README.md
+++ b/retail_cpg/pos_sales_returns/README.md
@@ -31,3 +31,7 @@ Expected rows: ~200 stores, 5k products, 50k orders, 150k items, 5k returns.
 ## Efficiency Notes
 Indexes support lookups by store/date and product popularity; sample tasks
 contrast date-first vs full-scan approaches.
+
+## Denormalized Mart Trade-offs
+The `store_daily_sales` mart pre-aggregates revenue and returns for faster reporting
+but duplicates figures from orders; late adjustments require recomputation.

--- a/retail_cpg/pricing_promotions_lift/README.md
+++ b/retail_cpg/pricing_promotions_lift/README.md
@@ -20,3 +20,7 @@ Analyzes effect of promotions on sales lift across product categories.
 
 ## Efficiency Notes
 Indexes support receipt lookups by product and date.
+
+## Denormalized Mart Trade-offs
+The `receipt_promos` mart flattens product and promotion details for analysis but
+stores redundant product names and promo codes, increasing storage and rebuild cost.

--- a/retail_cpg/supply_chain_replenishment/README.md
+++ b/retail_cpg/supply_chain_replenishment/README.md
@@ -20,3 +20,7 @@ Models stock levels and replenishment orders to maintain inventory.
 
 ## Efficiency Notes
 Indexes support fast lookups for reorder analysis.
+
+## Denormalized Mart Trade-offs
+The stock and order mart repeats store and SKU attributes for quick dashboarding
+but requires regeneration when upstream details change.

--- a/retail_cpg/supply_chain_replenishment/schema_normalized.sql
+++ b/retail_cpg/supply_chain_replenishment/schema_normalized.sql
@@ -28,3 +28,4 @@ CREATE TABLE lead_times (
     sku_id INTEGER PRIMARY KEY REFERENCES skus(id),
     avg_days INTEGER NOT NULL CHECK(avg_days>0)
 );
+CREATE INDEX idx_leadtime_days ON lead_times(avg_days);


### PR DESCRIPTION
## Summary
- Build assortment_catalog schema with FKs, enums, and indexes
- Populate normalized and denormalized product catalog tables
- Document mart trade-offs across retail_cpg subdomains

## Testing
- `PYTHONPATH=. make check DOMAIN=Retail_CPG` *(fails: missing schemas in other subdomains)*

------
https://chatgpt.com/codex/tasks/task_e_68bd33390754832f9628f4892e4f1aba